### PR TITLE
Add git diff styling for AI suggestions

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -684,6 +684,41 @@ body {
   color: var(--gray-700);
 }
 
+.code-block-marker {
+  color: var(--gray-500);
+  font-style: italic;
+}
+
+.diff-added {
+  background: #e6ffed;
+  color: #22863a;
+  padding: 0 4px;
+  margin: var(--space-sm) 0;
+  border-left: 3px solid #34d058;
+}
+
+.diff-removed {
+  background: #ffeef0;
+  color: #b31d28;
+  padding: 0 4px;
+  margin: var(--space-sm) 0;
+  border-left: 3px solid #d73a49;
+}
+
+.diff-meta {
+  color: #6a737d;
+  font-style: italic;
+  margin: var(--space-sm) 0;
+}
+
+.diff-hunk {
+  background: #f1f8ff;
+  color: #005cc5;
+  padding: 0 4px;
+  margin: var(--space-sm) 0;
+  font-weight: 600;
+}
+
 /* Context Chunks */
 .context-chunks {
   margin-top: var(--space-xl);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -369,11 +369,30 @@ function App() {
         
         <div className="suggestion-content">
           <div className="suggestion-text">
-            {suggestions.suggestion.split('\n').map((line, index) => (
-              <div key={index} className={line.startsWith('```') ? 'code-block' : 'text-line'}>
-                {line}
-              </div>
-            ))}
+            {suggestions.suggestion.split('\n').map((line, index) => {
+              let lineClass = 'text-line';
+              if (line.startsWith('```')) {
+                lineClass = 'code-block-marker';
+              } else if (line.startsWith('+')) {
+                lineClass = 'diff-added';
+              } else if (line.startsWith('-')) {
+                lineClass = 'diff-removed';
+              } else if (line.startsWith('@@')) {
+                lineClass = 'diff-hunk';
+              } else if (
+                line.startsWith('diff') ||
+                line.startsWith('index') ||
+                line.startsWith('---') ||
+                line.startsWith('+++')
+              ) {
+                lineClass = 'diff-meta';
+              }
+              return (
+                <div key={index} className={lineClass}>
+                  {line}
+                </div>
+              );
+            })}
           </div>
         </div>
         


### PR DESCRIPTION
## Summary
- add diff color styles in the frontend
- render AI code suggestions with git diff formatting

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: requests, playwright, httpx)*

------
https://chatgpt.com/codex/tasks/task_e_683fbef257b48330a98b85c134046379